### PR TITLE
Paperwork: new link, not Linux only

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Contributions are welcome, as is feedback.
 * [moz-hocr-editor](https://github.com/garrison/moz-hocr-edit) - Firefox Addon for editing hOCR files **Discontinued**
 * [qt-box-editor](https://github.com/zdenop/qt-box-editor) - QT4 editor of tesseract-ocr box files.
 * [ocr-gt-tools](https://github.com/UB-Mannheim/ocr-gt-tools) - Client-Server application for editing OCR ground truth.
-* [Paperwork](https://github.com/jflesch/paperwork) - Using scanners and OCR to grep paper documents the easy way (Linux only).
+* [Paperwork](https://github.com/openpaperwork/paperwork) - Using scanners and OCR to grep paper documents the easy way.
 * [Paperless](https://github.com/danielquinn/paperless) - Scan, index, and archive all of your paper documents.
 * [gImageReader](https://github.com/manisandro/gImageReader) - gImageReader is a simple Gtk/Qt front-end to tesseract-ocr.
 * [VietOCR](http://vietocr.sourceforge.net/) - A Java/.NET GUI frontend for Tesseract OCR engine, including [jTessBoxEditor](http://vietocr.sourceforge.net/training.html) a graphical Tesseract [box data](https://github.com/tesseract-ocr/tesseract/wiki/Make-Box-Files) editor


### PR DESCRIPTION
- Repo moved to `openpaperwork` organization
- Windows support is explicitly advertised now (plus, other Unix-like systems of course should work)