### PR TITLE
Add PAGE XML to OCR (file) formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Contributions are welcome, as is feedback.
 		* [hOCR](#hocr)
 		* [ALTO XML](#alto-xml)
 		* [TEI](#tei)
+		* [PAGE XML](#page-xml)
 	* [OCR CLI](#ocr-cli)
 	* [OCR GUI](#ocr-gui)
 	* [OCR Preprocessing](#ocr-preprocessing)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Contributions are welcome, as is feedback.
 * [TEI SIG on Libraries](http://www.tei-c.org/SIG/Libraries/teiinlibraries/main-driver.html) - Best Practices for TEI in Libraries
 * [GDZ](http://gdz.sub.uni-goettingen.de/uploads/media/GDZ_document_format_2005_12_08.pdf) - METS/TEI-based GDZ document format
 
+#### PAGE XML
+
+* [PAGE-XML Schema](https://github.com/PRImA-Research-Lab/PAGE-XML/tree/master/pagecontent) - XML schema of the PAGE XML format along with documentation and examples
+
 ### OCR CLI
 
 * [OCRmyPDF](https://github.com/jbarlow83/OCRmyPDF) - OCRmyPDF adds an OCR text layer to scanned PDF files, allowing them to be searched


### PR DESCRIPTION
The PAGE XML format is often used in scientific competitions. It
is also the standard output formt of the tools developed in the
context of OCR-D.