### PR TITLE
node-tesseract-ocr

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Contributions are welcome, as is feedback.
 * [gocr.js](https://github.com/antimatter15/gocr.js) - Javascript port (emscripten) of gocr
 * [ocrad.js](https://github.com/antimatter15/ocrad.js) - Javascript port (emscripten) of ocrad
 * [tesseract.js](https://github.com/naptha/tesseract.js) - Javascript port (emscripten) of Tesseract
-* [node-tesseract](https://github.com/desmondmorris/node-tesseract) - A simple wrapper for the Tesseract OCR package.
+* [node-tesseract-ocr](https://github.com/zapolnoch/node-tesseract-ocr) - A simple wrapper for the Tesseract OCR package.
 * [node-tesseract-native](https://github.com/mdelete/node-tesseract-native) - C++ module for node providing OCR with tesseract and leptonica.
 
 #### Ruby


### PR DESCRIPTION
``node-tesseract`` project seems abandoned. Many issues and no commits since 2017.
Here is a new and improved [version](https://github.com/zapolnoch/node-tesseract-ocr).