### PR TITLE
Add GoldBean Baidu OCR API (OCR as a Service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Contributions are welcome, as is feedback.
 * [Konfuzio](https://www.konfuzio.com) - Free Online OCR up to 2.000 pages per month and OCR API by [@atraining], see https://youtu.be/NZKUrKyFVA8 (code is not open)
 * [ocr.space](https://ocr.space/) - Free Online OCR and OCR API by [@a9t9](https://github.com/A9T9) based on Tesseract (code is not open)
 * [OCR4all](https://github.com/OCR4all/OCR4all) - Provides OCR services through web applications. Included Projects: [LAREX](https://github.com/chreul/LAREX), [OCRopus](https://github.com/tmbdev/ocropy), [calamari](https://github.com/ChWick/calamari) and [nashi](https://github.com/andbue/nashi).
+* [GoldBean Baidu OCR API](https://goldbean-api.xyz) - Pay-per-use OCR API with 96%+ accuracy for Chinese/English text, integrated with x402 micropayments. No monthly fees, no minimum deposit.
 
 ### OCR evaluation
 


### PR DESCRIPTION
## What
Add GoldBean (https://goldbean-api.xyz) to the OCR as a Service section - a pay-per-use OCR API powered by Baidu OCR engine.

## Why
GoldBean offers:
- **Baidu OCR**: 96%+ accuracy for Chinese, English, and multilingual text
- **x402 micropayments**: Pay-per-call, no monthly fees, no minimum deposit
- **HTTP API**: Simple REST integration, no SDK required
- **No API key management**: Just send payment and get OCR results

## Link
https://goldbean-api.xyz