### PR TITLE
Add ocrcontext – LLM-agnostic OCR library with LangChain integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Contributions are welcome, as is feedback.
 * [pyocr](https://github.com/jflesch/pyocr) - A Python wrapper for Tesseract and Cuneiform.
 * [ocrodjvu](https://github.com/jwilk/ocrodjvu) - A library and standalone tool for doing OCR on DjVu documents, wrapping Cuneiform, gocr, ocrad, ocropus and tesseract
 * [tesserocr](https://github.com/sirfz/tesserocr) - A Python wrapper for the tesseract-ocr API
+* [ocrcontext](https://github.com/BahadirKarsli/OCRContext) - LLM-agnostic document OCR library with smart engine routing (PaddleOCR / Google Vision / TrOCR), fidelity-first LLM refinement, and Pydantic schema extraction. `MIT`
 
 #### Javascript
 


### PR DESCRIPTION
ocrcontext is a pip-installable Python library for document OCR and structured extraction.

- Smart engine routing: digital PDF → PyMuPDF, image/scanned PDF → PaddleOCR, handwriting → Google Cloud Vision / TrOCR
- Fidelity-first LLM refinement with drift guard and literal masking
- Structured extraction via Pydantic schemas
- LangChain-native document loader
- MIT license

PyPI: https://pypi.org/project/ocrcontext/